### PR TITLE
Simplify filtering regexp

### DIFF
--- a/→za-readurl-preinit-handler
+++ b/→za-readurl-preinit-handler
@@ -155,7 +155,7 @@ for cur_paturl ( $pattern_url0 $pattern_url ) {
     }
 
     if [[ -n $filters[index] ]] {
-        list=( ${list[@]:#href=(?|)$~filters[index]} )
+        list=( ${list[@]:#href=${~filters[index]}} )
     }
 
     local selected=${list[1]#href=}


### PR DESCRIPTION
Fixes #6.

Filter alpha/beta versions for terraform with:
```
zinit id-as'terraform' as'readurl|command' extract dlink0'/terraform/%VERSION%~%.*(alpha|beta).*%/' \
      dlink'/terraform/%VERSION%/terraform_%VERSION%_linux_amd64.zip' \
      for https://releases.hashicorp.com/terraform/
```